### PR TITLE
Exclude auth headers from preflight and include thread name in report…

### DIFF
--- a/src/main/java/nz/co/breakpoint/jmeter/modifiers/CorsPreProcessor.java
+++ b/src/main/java/nz/co/breakpoint/jmeter/modifiers/CorsPreProcessor.java
@@ -127,14 +127,13 @@ public class CorsPreProcessor extends AbstractTestElement
         if (method.matches(allowedMethods) && preflightHeaders.isEmpty()) return; // simple request
 
         HTTPSamplerBase preflight = (HTTPSamplerBase) sampler.clone();
-        HeaderManager hm = new HeaderManager();
+        HeaderManager hm = preflight.getHeaderManager();
         hm.removeHeaderNamed(AUTHORIZATION);
         hm.removeHeaderNamed(ACCEPT);
         hm.add(new Header(ACCEPT, "*/*"));
         hm.add(new Header(ACCESS_CONTROL_REQUEST_METHOD, method));
         hm.add(new Header(ACCESS_CONTROL_REQUEST_HEADERS, String.join(",", preflightHeaders)));
 
-        preflight.setHeaderManager(hm);
         preflight.setMethod(OPTIONS);
         preflight.setName(preflight.getName() + getPreflightLabelSuffix());
         preflight.setThreadContext(context);
@@ -145,6 +144,7 @@ public class CorsPreProcessor extends AbstractTestElement
             return;
         }
         SampleResult result = preflight.sample();
+        result.setThreadName(context.getThread().getThreadName());
         addToPreflightCache(result);
         notifier.notifyListeners(new SampleEvent(result, context.getThreadGroup().getName()), listeners);
     }

--- a/src/test/java/nz/co/breakpoint/jmeter/modifiers/HTTPSamplerStub.java
+++ b/src/test/java/nz/co/breakpoint/jmeter/modifiers/HTTPSamplerStub.java
@@ -1,6 +1,11 @@
 package nz.co.breakpoint.jmeter.modifiers;
 
 import java.net.URL;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
 import org.apache.jmeter.protocol.http.control.Header;
 import org.apache.jmeter.protocol.http.control.HeaderManager;
 import org.apache.jmeter.protocol.http.sampler.HTTPSamplerBase;
@@ -36,6 +41,15 @@ public class HTTPSamplerStub extends HTTPSamplerBase {
         result.setSampleLabel(url.toString());
         result.setHTTPMethod(method);
         result.setURL(url);
+
+        result.setRequestHeaders(StreamSupport.stream(
+            Spliterators.spliteratorUnknownSize(getHeaderManager().getHeaders().iterator(), Spliterator.ORDERED), false)
+                .map(headerProp -> {
+                    Header header = (Header) headerProp.getObjectValue();
+                    return String.format("%s: %s", header.getName(), header.getValue());
+                })
+                .collect(Collectors.joining("\n"))
+        );
         result.setResponseHeaders(String.format(
             "Access-Control-Max-Age: %d\n" +
             "Access-Control-Allow-Headers: %s\n" +

--- a/src/test/java/nz/co/breakpoint/jmeter/modifiers/TestCorsPreProcessor.java
+++ b/src/test/java/nz/co/breakpoint/jmeter/modifiers/TestCorsPreProcessor.java
@@ -9,8 +9,6 @@ import org.apache.jmeter.threads.JMeterContextService;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import java.net.MalformedURLException;
 import java.util.Arrays;
 
 import static org.junit.Assert.*;
@@ -105,6 +103,15 @@ public class TestCorsPreProcessor {
         instance.process();
         instance.process();
         assertEquals(2, resultsListener.results.size());
+    }
+
+    @Test
+    public void itShouldRemoveAuthHeaderFromPreflight() {
+        sampler.addHeader("Authorization", "something secret");
+        instance.process();
+        assertEquals(1, resultsListener.results.size());
+        HTTPSampleResult result = resultsListener.results.get(0);
+        assertFalse(result.getRequestHeaders().contains("Authorization:"));
     }
 
 }


### PR DESCRIPTION
Thanks for creating this module. I found it useful for simplifying my test plan.

I found that without this patch there were two issues with the OPTIONS requests.

1. Authorization headers were not stripped from the OPTIONS requests
2. Jmeter was not logging the thread name in the results CSV file making it difficult to trace which thread was responsible for which OPTIONS request in the logs.

